### PR TITLE
0.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-highlight",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "React component for syntax highlighting",
   "main": "index.js",
   "scripts": {
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/akiran/react-highlight",
   "dependencies": {
-    "highlight.js": "^9.11.0"
+    "highlight.js": "9.11.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.7",


### PR DESCRIPTION
Set highlight.js to version 9.11.0 to try to avoid errors thrown due to 'const'. For example, when doing a webpack build, UglifyJs throws:
```
Unexpected token: keyword (const) [./node_modules/highlight.js/lib/languages/reasonml.js:36,0][33-chunk-ad7e81b972059fad92fe.js:18860,2]
```
Setting highlight.js to specific version before 'const' was introduced.

